### PR TITLE
Add a genkitx evaluator plugin - Promptfoo

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ Genkit is a framework designed to help you build AI-powered applications and fea
    - [`genkitx-pgvector`](https://www.npmjs.com/package/genkitx-pgvector) - Plugin for PostgeSQL (PGVector) Vector Stores.
    - [`genkitx-tidb`](https://github.com/BelfoSamad/genkitx-tidb) - Plugin for TiDB Vector Stores.
    - [`genkitx-redis`](https://github.com/retzd-tech/genkitx-redis) - Plugin for Redis Vector Stores.
-3. Other Plugins
+3. Evaluator Plugins
+   - [`genkitx-promptfoo`](https://github.com/yukinagae/genkitx-promptfoo) - Plugin for Promptfoo Evaluations.
+4. Other Plugins
    - [`genkitx-graph`](https://github.com/TheFireCo/genkit-plugins/tree/main/plugins/graph) - Plugin for building Graph workflows.
    - [`@invertase/genkit-plugin-redis`](https://github.com/invertase/genkit-plugin-redis) - A Redis Plugin for GenKit that adds Redis for efficient state storage, trace storage, caching, and rate limiting.
    - [`genkitx-rxjs`](https://github.com/pavelgj/genkitx-rxjs) - A simple RxJS helper/adapter for Firebase Genkit.


### PR DESCRIPTION
## Describe The changes

This change is a:
[] Bug fix
[x] New awesome stuff
[] Documentation update
[] Other

Added a evaluator plugin, [genkitx-promptfoo](https://github.com/yukinagae/genkitx-promptfoo).
It utilizes [Promptfoo](https://github.com/promptfoo/promptfoo) assertions within Genkit to enhance the evaluation processes.

Like this pull request?  Vote for it by adding a :+1:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new section for "Evaluator Plugins" in the documentation.
	- Added the `genkitx-promptfoo` plugin specifically for Promptfoo Evaluations.
  
- **Documentation**
	- Renamed and reorganized the "Other Plugins" section for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->